### PR TITLE
Change in spec.files + add_runtime_dependency

### DIFF
--- a/logstash-filter-virustotal.gemspec
+++ b/logstash-filter-virustotal.gemspec
@@ -3,14 +3,16 @@ Gem::Specification.new do |s|
   s.version         = '0.1.1'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This filter queries the Virustotal API"
-  s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
+  s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors = ["CoolAcid"]
   s.email = 'jakendall@gmail.com'
   s.homepage = "http://www.coolacid.net"
   s.require_paths = ["lib"]
 
   # Files
-  s.files = `git ls-files`.split($\)
+  s.files = Dir['lib/   *.rb'] + Dir['bin/*']
+  s.files += Dir['[A-Z]*'] + Dir['test/**/*']
+  s.files.reject! { |fn| fn.include? "CVS" }
    # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
@@ -18,6 +20,6 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
 
   # Gem dependencies
-  s.add_runtime_dependency 'logstash-core', '>= 1.4.0', '< 2.0.0'
+  s.add_runtime_dependency 'logstash-core', '>= 2.0.0', '<= 2.3.2'
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
Problem with the git command in spec.files (change the command `git ls-files` )
Problem with logstash-core versioning (was valid for version between 1.4 to 2.0).

Tested on Logtash 2.3.2
